### PR TITLE
feat: [회원] 로그인 및 JWT/Spring Security 인증 시스템 구현 (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+gh
+gh.zip
+gh_2.45.0_macOS_amd64/

--- a/src/main/java/com/vibecoding/demo/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/controller/MemberApiController.java
@@ -1,9 +1,10 @@
 package com.vibecoding.demo.domain.member.controller;
 
-import com.vibecoding.demo.domain.member.dto.SignupRequest;
-import com.vibecoding.demo.domain.member.service.MemberService;
 import com.vibecoding.demo.domain.member.dto.LoginRequest;
+import com.vibecoding.demo.domain.member.dto.LoginResponse;
+import com.vibecoding.demo.domain.member.dto.SignupRequest;
 import com.vibecoding.demo.domain.member.dto.SignupResponse;
+import com.vibecoding.demo.domain.member.service.MemberService;
 import com.vibecoding.demo.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ public class MemberApiController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<SignupResponse>> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(ApiResponse.success("로그인이 완료되었습니다.", memberService.login(request)));
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/controller/MemberApiController.java
@@ -2,6 +2,7 @@ package com.vibecoding.demo.domain.member.controller;
 
 import com.vibecoding.demo.domain.member.dto.SignupRequest;
 import com.vibecoding.demo.domain.member.service.MemberService;
+import com.vibecoding.demo.domain.member.dto.LoginRequest;
 import com.vibecoding.demo.domain.member.dto.SignupResponse;
 import com.vibecoding.demo.global.dto.ApiResponse;
 import jakarta.validation.Valid;
@@ -22,5 +23,10 @@ public class MemberApiController {
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         return ResponseEntity.ok(ApiResponse.success("회원가입이 완료되었습니다.", memberService.signup(request)));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<SignupResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("로그인이 완료되었습니다.", memberService.login(request)));
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/member/dto/LoginRequest.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.vibecoding.demo.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank String loginId,
+    @NotBlank String password
+) {
+}

--- a/src/main/java/com/vibecoding/demo/domain/member/dto/LoginResponse.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/dto/LoginResponse.java
@@ -4,6 +4,7 @@ public record LoginResponse(
     Long id,
     String loginId,
     String name,
-    String accessToken
+    String accessToken,
+    String refreshToken
 ) {
 }

--- a/src/main/java/com/vibecoding/demo/domain/member/dto/LoginResponse.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/dto/LoginResponse.java
@@ -1,0 +1,9 @@
+package com.vibecoding.demo.domain.member.dto;
+
+public record LoginResponse(
+    Long id,
+    String loginId,
+    String name,
+    String accessToken
+) {
+}

--- a/src/main/java/com/vibecoding/demo/domain/member/service/MemberService.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.vibecoding.demo.domain.member.service;
 
+import com.vibecoding.demo.domain.member.dto.LoginRequest;
 import com.vibecoding.demo.domain.member.dto.SignupRequest;
+import com.vibecoding.demo.domain.member.dto.SignupResponse;
 import com.vibecoding.demo.domain.member.entity.Member;
 import com.vibecoding.demo.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,7 @@ public class MemberService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     @Transactional
-    public com.vibecoding.demo.domain.member.dto.SignupResponse signup(SignupRequest request) {
+    public SignupResponse signup(SignupRequest request) {
         if (memberRepository.existsByLoginId(request.loginId())) {
             throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
         }
@@ -33,10 +35,25 @@ public class MemberService {
                 .build();
 
         var savedMember = memberRepository.save(member);
-        return new com.vibecoding.demo.domain.member.dto.SignupResponse(
+        return new SignupResponse(
                 savedMember.getId(),
                 savedMember.getLoginId(),
                 savedMember.getName()
+        );
+    }
+
+    public SignupResponse login(LoginRequest request) {
+        var member = memberRepository.findByLoginId(request.loginId())
+                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다.");
+        }
+
+        return new SignupResponse(
+                member.getId(),
+                member.getLoginId(),
+                member.getName()
         );
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/member/service/MemberService.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/service/MemberService.java
@@ -65,11 +65,18 @@ public class MemberService {
                 userDetails.getAuthorities().iterator().next().getAuthority()
         );
 
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                userDetails.getMemberId(),
+                userDetails.getLoginId(),
+                userDetails.getAuthorities().iterator().next().getAuthority()
+        );
+
         return new LoginResponse(
                 userDetails.getMemberId(),
                 userDetails.getLoginId(),
                 userDetails.getName(),
-                accessToken
+                accessToken,
+                refreshToken
         );
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/member/service/MemberService.java
+++ b/src/main/java/com/vibecoding/demo/domain/member/service/MemberService.java
@@ -1,11 +1,17 @@
 package com.vibecoding.demo.domain.member.service;
 
 import com.vibecoding.demo.domain.member.dto.LoginRequest;
+import com.vibecoding.demo.domain.member.dto.LoginResponse;
 import com.vibecoding.demo.domain.member.dto.SignupRequest;
 import com.vibecoding.demo.domain.member.dto.SignupResponse;
 import com.vibecoding.demo.domain.member.entity.Member;
 import com.vibecoding.demo.domain.member.repository.MemberRepository;
+import com.vibecoding.demo.global.security.CustomUserDetails;
+import com.vibecoding.demo.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +23,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManager authenticationManager;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -42,18 +50,26 @@ public class MemberService {
         );
     }
 
-    public SignupResponse login(LoginRequest request) {
-        var member = memberRepository.findByLoginId(request.loginId())
-                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
+    public LoginResponse login(LoginRequest request) {
+        UsernamePasswordAuthenticationToken authenticationToken = 
+                new UsernamePasswordAuthenticationToken(request.loginId(), request.password());
+        
+        // AuthenticationManager를 통한 검증 (내부적으로 CustomUserDetailsService 호출)
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+        
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
-            throw new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다.");
-        }
+        String accessToken = jwtTokenProvider.createAccessToken(
+                userDetails.getMemberId(),
+                userDetails.getLoginId(),
+                userDetails.getAuthorities().iterator().next().getAuthority()
+        );
 
-        return new SignupResponse(
-                member.getId(),
-                member.getLoginId(),
-                member.getName()
+        return new LoginResponse(
+                userDetails.getMemberId(),
+                userDetails.getLoginId(),
+                userDetails.getName(),
+                accessToken
         );
     }
 }

--- a/src/main/java/com/vibecoding/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/vibecoding/demo/global/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/signup").permitAll()
+                        .requestMatchers("/api/members/signup", "/api/members/login").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/vibecoding/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/vibecoding/demo/global/config/SecurityConfig.java
@@ -1,21 +1,34 @@
 package com.vibecoding.demo.global.config;
 
+import com.vibecoding.demo.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean
@@ -26,7 +39,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/members/signup", "/api/members/login").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/vibecoding/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/vibecoding/demo/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.vibecoding.demo.global.exception;
+
+import com.vibecoding.demo.global.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Handling IllegalArgumentException: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        log.warn("Validation error: {}", message);
+        return ResponseEntity.badRequest().body(ApiResponse.error(message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Internal server error", e);
+        return ResponseEntity.internalServerError().body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/vibecoding/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/vibecoding/demo/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.vibecoding.demo.global.exception;
 import com.vibecoding.demo.global.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,10 +13,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
-        log.warn("Handling IllegalArgumentException: {}", e.getMessage());
-        return ResponseEntity.badRequest().body(ApiResponse.error(e.getMessage()));
+    @ExceptionHandler({IllegalArgumentException.class, BadCredentialsException.class, UsernameNotFoundException.class})
+    public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(RuntimeException e) {
+        log.warn("Authentication failed: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(ApiResponse.error("아이디 또는 비밀번호가 일치하지 않습니다."));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/vibecoding/demo/global/security/CustomUserDetails.java
+++ b/src/main/java/com/vibecoding/demo/global/security/CustomUserDetails.java
@@ -1,0 +1,63 @@
+package com.vibecoding.demo.global.security;
+
+import com.vibecoding.demo.domain.member.entity.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long memberId;
+    private final String loginId;
+    private final String password;
+    private final String name;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Member member) {
+        this.memberId = member.getId();
+        this.loginId = member.getLoginId();
+        this.password = member.getPassword();
+        this.name = member.getName();
+        this.authorities = Collections.singletonList(new SimpleGrantedAuthority(member.getRole().getValue()));
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return loginId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/vibecoding/demo/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/vibecoding/demo/global/security/CustomUserDetailsService.java
@@ -1,0 +1,22 @@
+package com.vibecoding.demo.global.security;
+
+import com.vibecoding.demo.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findByLoginId(username)
+                .map(CustomUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+    }
+}

--- a/src/main/java/com/vibecoding/demo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vibecoding/demo/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.vibecoding.demo.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            String loginId = jwtTokenProvider.getClaims(token).getSubject();
+            UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+            
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/vibecoding/demo/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/vibecoding/demo/global/security/JwtTokenProvider.java
@@ -16,18 +16,29 @@ public class JwtTokenProvider {
 
     private final Key key;
     private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds) {
+            @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds,
+            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.accessTokenValidityInMilliseconds = accessTokenValidityInSeconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;
     }
 
     public String createAccessToken(Long memberId, String loginId, String role) {
+        return createToken(memberId, loginId, role, accessTokenValidityInMilliseconds);
+    }
+
+    public String createRefreshToken(Long memberId, String loginId, String role) {
+        return createToken(memberId, loginId, role, refreshTokenValidityInMilliseconds);
+    }
+
+    private String createToken(Long memberId, String loginId, String role, long validityInMilliseconds) {
         Date now = new Date();
-        Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()
                 .setSubject(loginId)

--- a/src/main/java/com/vibecoding/demo/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/vibecoding/demo/global/security/JwtTokenProvider.java
@@ -1,0 +1,58 @@
+package com.vibecoding.demo.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private final long accessTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInSeconds * 1000;
+    }
+
+    public String createAccessToken(Long memberId, String loginId, String role) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(loginId)
+                .claim("memberId", memberId)
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/test/java/com/vibecoding/demo/domain/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/member/controller/MemberApiControllerTest.java
@@ -1,0 +1,55 @@
+package com.vibecoding.demo.domain.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibecoding.demo.domain.member.dto.LoginRequest;
+import com.vibecoding.demo.domain.member.dto.SignupResponse;
+import com.vibecoding.demo.domain.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberApiController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMappingContext;
+
+    @Test
+    @DisplayName("로그인 실패 시 400 에러와 함께 에러 메시지를 반환한다")
+    void login_fail_response() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("failuser", "wrongpass");
+        given(memberService.login(any(LoginRequest.class)))
+                .willThrow(new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
+
+        // when & then
+        mockMvc.perform(post("/api/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("아이디 또는 비밀번호가 일치하지 않습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/src/test/java/com/vibecoding/demo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/member/service/MemberServiceTest.java
@@ -75,6 +75,7 @@ class MemberServiceTest {
         assertThat(response.loginId()).isEqualTo("user1");
         assertThat(response.name()).isEqualTo("유저1");
         assertThat(response.accessToken()).isNotBlank();
+        assertThat(response.refreshToken()).isNotBlank();
     }
 
     @Test

--- a/src/test/java/com/vibecoding/demo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.vibecoding.demo.domain.member.service;
 
+import com.vibecoding.demo.domain.member.dto.LoginRequest;
 import com.vibecoding.demo.domain.member.dto.SignupRequest;
 import com.vibecoding.demo.domain.member.dto.SignupResponse;
 import com.vibecoding.demo.domain.member.repository.MemberRepository;
@@ -11,6 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -53,5 +55,47 @@ class MemberServiceTest {
         // 비밀번호 암호화 확인
         assertThat(passwordEncoder.matches("password123!", savedMember.getPassword())).isTrue();
         assertThat(savedMember.getPassword()).isNotEqualTo("password123!");
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - 아이디와 비밀번호가 일치하는 경우")
+    void login_success() {
+        // given
+        SignupRequest signupRequest = new SignupRequest("user1", "pass1", "유저1", "u1@ex.com");
+        memberService.signup(signupRequest);
+        LoginRequest loginRequest = new LoginRequest("user1", "pass1");
+
+        // when
+        SignupResponse response = memberService.login(loginRequest);
+
+        // then
+        assertThat(response.loginId()).isEqualTo("user1");
+        assertThat(response.name()).isEqualTo("유저1");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 아이디가 존재하지 않는 경우")
+    void login_fail_invalid_id() {
+        // given
+        LoginRequest loginRequest = new LoginRequest("nonexistent", "password");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.login(loginRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("아이디 또는 비밀번호가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호가 틀린 경우")
+    void login_fail_invalid_password() {
+        // given
+        SignupRequest signupRequest = new SignupRequest("user1", "pass1", "유저1", "u1@ex.com");
+        memberService.signup(signupRequest);
+        LoginRequest loginRequest = new LoginRequest("user1", "wrongpass");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.login(loginRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("아이디 또는 비밀번호가 일치하지 않습니다.");
     }
 }

--- a/src/test/java/com/vibecoding/demo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.vibecoding.demo.domain.member.service;
 
 import com.vibecoding.demo.domain.member.dto.LoginRequest;
+import com.vibecoding.demo.domain.member.dto.LoginResponse;
 import com.vibecoding.demo.domain.member.dto.SignupRequest;
 import com.vibecoding.demo.domain.member.dto.SignupResponse;
 import com.vibecoding.demo.domain.member.repository.MemberRepository;
@@ -8,6 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,7 +61,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 - 아이디와 비밀번호가 일치하는 경우")
+    @DisplayName("로그인 성공 - 아이디와 비밀번호가 일치하는 경우 JWT 발급 확인")
     void login_success() {
         // given
         SignupRequest signupRequest = new SignupRequest("user1", "pass1", "유저1", "u1@ex.com");
@@ -66,11 +69,12 @@ class MemberServiceTest {
         LoginRequest loginRequest = new LoginRequest("user1", "pass1");
 
         // when
-        SignupResponse response = memberService.login(loginRequest);
+        LoginResponse response = memberService.login(loginRequest);
 
         // then
         assertThat(response.loginId()).isEqualTo("user1");
         assertThat(response.name()).isEqualTo("유저1");
+        assertThat(response.accessToken()).isNotBlank();
     }
 
     @Test
@@ -81,8 +85,7 @@ class MemberServiceTest {
 
         // when & then
         assertThatThrownBy(() -> memberService.login(loginRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("아이디 또는 비밀번호가 일치하지 않습니다.");
+                .isInstanceOfAny(BadCredentialsException.class, UsernameNotFoundException.class);
     }
 
     @Test
@@ -95,7 +98,6 @@ class MemberServiceTest {
 
         // when & then
         assertThatThrownBy(() -> memberService.login(loginRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("아이디 또는 비밀번호가 일치하지 않습니다.");
+                .isInstanceOf(BadCredentialsException.class);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,3 +12,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+jwt:
+  secret: c2VjcmV0LWtleS12aWJlY29kaW5nLXNwcmluZ2Jvb3QtYXBwbGljYXRpb24tc2VjcmV0LXZlcnktbG9uZw==
+  access-token-validity-in-seconds: 3600
+  refresh-token-validity-in-seconds: 1209600


### PR DESCRIPTION
## 📌 개요
  이슈 #24번의 요구사항에 따라 ID/PW 기반의 로그인 기능과 JWT를 활용한 Stateless 인증 체계를 구현했습니다. Spring Security의
  표준 인증 프로세스를 도입하여 보안성과 유지보수성을 확보했습니다.

 ## ✨ 주요 작업 내용
   - Spring Security 기반 인증 프로세스 구축
     - CustomUserDetailsService, CustomUserDetails 구현을 통해 DB 회원 정보를 Security 인증 모델과 연동했습니다.
     - AuthenticationManager를 활용하여 표준화된 비밀번호 검증 로직을 적용했습니다.
   - 이중 토큰(JWT) 발급 시스템
     - JwtTokenProvider: Access Token 및 Refresh Token 발급/검증 로직을 구현했습니다.
     - 로그인 성공 시 사용자 정보와 함께 두 종류의 토큰을 모두 반환하여 보안을 강화했습니다.
   - JWT 인증 필터 구현 (JwtAuthenticationFilter)
     - 모든 요청의 Header에서 JWT를 추출하여 유효성을 검사하고 SecurityContext에 인증 정보를 등록하는 필터를 추가했습니다.
   - 전역 예외 처리 및 응답 표준화
     - GlobalExceptionHandler: 로그인 실패(BadCredentialsException 등) 및 유효성 검사 실패 시 표준화된 ApiResponse 형식의
       에러 메시지를 반환하도록 처리했습니다.
   - 보안 설정 (SecurityConfig)
     - 세션 정책을 STATELESS로 설정하고 JWT 필터를 보안 체인에 등록했습니다.
     - 회원가입 및 로그인 API에 대한 무인증 접근을 허용했습니다.

 ## 📸 테스트 결과
   - 서비스 테스트 (MemberServiceTest):
     - 로그인 성공 시 회원 정보 및 이중 토큰 발급 확인 완료.
     - 존재하지 않는 ID 또는 잘못된 PW 입력 시 예외 발생 확인 완료.
   - API 테스트 (MemberApiControllerTest):
     - 예외 발생 시 전역 예외 처리기를 통한 에러 응답 구조(JSON) 검증 완료.

 ## 🔗 관련 이슈
   - Close #24