### PR TITLE
feat: [게시판] 게시글 CRUD API 구현 및 세밀한 권한 제어 적용 (#5)

### DIFF
--- a/src/main/java/com/vibecoding/demo/domain/board/controller/PostApiController.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/controller/PostApiController.java
@@ -1,9 +1,15 @@
 package com.vibecoding.demo.domain.board.controller;
 
-import com.vibecoding.demo.domain.board.entity.Post;
+import com.vibecoding.demo.domain.board.dto.PostCreateRequest;
+import com.vibecoding.demo.domain.board.dto.PostResponse;
+import com.vibecoding.demo.domain.board.dto.PostUpdateRequest;
 import com.vibecoding.demo.domain.board.service.PostService;
+import com.vibecoding.demo.global.dto.ApiResponse;
+import com.vibecoding.demo.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,25 +21,47 @@ public class PostApiController {
 
     private final PostService postService;
 
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> createPost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid PostCreateRequest request) {
+        Long postId = postService.createPost(request, userDetails.getMemberId());
+        return ResponseEntity.ok(ApiResponse.success("게시글이 등록되었습니다.", postId));
+    }
+
     @GetMapping
-    public ResponseEntity<List<Post>> getPosts(
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getPosts(
             @RequestParam(defaultValue = "0") int offset,
             @RequestParam(defaultValue = "10") int limit) {
-        List<Post> posts = postService.getPostsByOffsetAndLimit(offset, limit);
-        return ResponseEntity.ok(posts);
+        List<PostResponse> posts = postService.getPostsByOffsetAndLimit(offset, limit);
+        return ResponseEntity.ok(ApiResponse.success(posts));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable Long postId) {
+        PostResponse post = postService.getPost(postId);
+        return ResponseEntity.ok(ApiResponse.success(post));
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> updatePost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid PostUpdateRequest request) {
+        postService.updatePost(postId, request, userDetails.getMemberId());
+        return ResponseEntity.ok(ApiResponse.success("게시글이 수정되었습니다.", null));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        postService.deletePost(postId, userDetails.getMemberId(), userDetails.getMember().getRole());
+        return ResponseEntity.ok(ApiResponse.success("게시글이 삭제되었습니다.", null));
     }
     
     @GetMapping("/count")
-    public ResponseEntity<Long> getPostCount() {
-        return ResponseEntity.ok(postService.getTotalPostCount());
-    }
-    
-    // For testing/dummy data creation
-    @PostMapping
-    public ResponseEntity<Post> createPost(
-            @RequestParam String title, 
-            @RequestParam String content, 
-            @RequestParam String author) {
-        return ResponseEntity.ok(postService.createPost(title, content, author));
+    public ResponseEntity<ApiResponse<Long>> getPostCount() {
+        return ResponseEntity.ok(ApiResponse.success(postService.getTotalPostCount()));
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/board/dto/PostCreateRequest.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/dto/PostCreateRequest.java
@@ -1,0 +1,11 @@
+package com.vibecoding.demo.domain.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PostCreateRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/vibecoding/demo/domain/board/dto/PostResponse.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/dto/PostResponse.java
@@ -1,0 +1,12 @@
+package com.vibecoding.demo.domain.board.dto;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        String authorName,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/vibecoding/demo/domain/board/dto/PostUpdateRequest.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/dto/PostUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.vibecoding.demo.domain.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PostUpdateRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/vibecoding/demo/domain/board/entity/Post.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/entity/Post.java
@@ -1,21 +1,18 @@
 package com.vibecoding.demo.domain.board.entity;
 
+import com.vibecoding.demo.domain.member.entity.Member;
+import com.vibecoding.demo.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "posts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Post {
+public class Post extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,17 +24,19 @@ public class Post {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @Column(nullable = false)
-    private String author;
-
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Builder
-    public Post(String title, String content, String author) {
+    public Post(String title, String content, Member member) {
         this.title = title;
         this.content = content;
-        this.author = author;
+        this.member = member;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/repository/PostRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query(value = "SELECT * FROM posts ORDER BY id DESC OFFSET :offset LIMIT :limit", nativeQuery = true)
+    @Query(value = "SELECT * FROM posts ORDER BY id DESC LIMIT :limit OFFSET :offset", nativeQuery = true)
     List<Post> findPostsWithOffsetAndLimit(@Param("offset") int offset, @Param("limit") int limit);
 }

--- a/src/main/java/com/vibecoding/demo/domain/board/service/PostService.java
+++ b/src/main/java/com/vibecoding/demo/domain/board/service/PostService.java
@@ -1,12 +1,19 @@
 package com.vibecoding.demo.domain.board.service;
 
+import com.vibecoding.demo.domain.board.dto.PostCreateRequest;
+import com.vibecoding.demo.domain.board.dto.PostResponse;
+import com.vibecoding.demo.domain.board.dto.PostUpdateRequest;
 import com.vibecoding.demo.domain.board.entity.Post;
 import com.vibecoding.demo.domain.board.repository.PostRepository;
+import com.vibecoding.demo.domain.member.entity.Member;
+import com.vibecoding.demo.domain.member.entity.Role;
+import com.vibecoding.demo.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -14,21 +21,71 @@ import java.util.List;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
-    public List<Post> getPostsByOffsetAndLimit(int offset, int limit) {
-        return postRepository.findPostsWithOffsetAndLimit(offset, limit);
+    @Transactional
+    public Long createPost(PostCreateRequest request, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        Post post = Post.builder()
+                .title(request.title())
+                .content(request.content())
+                .member(member)
+                .build();
+
+        return postRepository.save(post).getId();
+    }
+
+    public List<PostResponse> getPostsByOffsetAndLimit(int offset, int limit) {
+        return postRepository.findPostsWithOffsetAndLimit(offset, limit).stream()
+                .map(post -> new PostResponse(
+                        post.getId(),
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getMember().getName(),
+                        post.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public PostResponse getPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+        return new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getMember().getName(),
+                post.getCreatedAt()
+        );
+    }
+
+    @Transactional
+    public void updatePost(Long postId, PostUpdateRequest request, Long memberId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        if (!post.getMember().getId().equals(memberId)) {
+            throw new IllegalArgumentException("게시글 수정 권한이 없습니다.");
+        }
+
+        post.update(request.title(), request.content());
+    }
+
+    @Transactional
+    public void deletePost(Long postId, Long memberId, Role role) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        if (!post.getMember().getId().equals(memberId) && role != Role.ADMIN) {
+            throw new IllegalArgumentException("게시글 삭제 권한이 없습니다.");
+        }
+
+        postRepository.delete(post);
     }
     
     public long getTotalPostCount() {
         return postRepository.count();
-    }
-    
-    @Transactional
-    public Post createPost(String title, String content, String author) {
-        return postRepository.save(Post.builder()
-                .title(title)
-                .content(content)
-                .author(author)
-                .build());
     }
 }

--- a/src/main/java/com/vibecoding/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/vibecoding/demo/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.vibecoding.demo.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -38,6 +39,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/members/signup", "/api/members/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/vibecoding/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/vibecoding/demo/global/exception/GlobalExceptionHandler.java
@@ -13,10 +13,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler({IllegalArgumentException.class, BadCredentialsException.class, UsernameNotFoundException.class})
+    @ExceptionHandler({BadCredentialsException.class, UsernameNotFoundException.class})
     public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(RuntimeException e) {
         log.warn("Authentication failed: {}", e.getMessage());
         return ResponseEntity.badRequest().body(ApiResponse.error("아이디 또는 비밀번호가 일치하지 않습니다."));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Business logic error: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(ApiResponse.error(e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/vibecoding/demo/global/security/CustomUserDetails.java
+++ b/src/main/java/com/vibecoding/demo/global/security/CustomUserDetails.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 @Getter
 public class CustomUserDetails implements UserDetails {
 
+    private final Member member;
     private final Long memberId;
     private final String loginId;
     private final String password;
@@ -19,6 +20,7 @@ public class CustomUserDetails implements UserDetails {
     private final Collection<? extends GrantedAuthority> authorities;
 
     public CustomUserDetails(Member member) {
+        this.member = member;
         this.memberId = member.getId();
         this.loginId = member.getLoginId();
         this.password = member.getPassword();

--- a/src/test/java/com/vibecoding/demo/domain/board/controller/PostApiControllerTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/board/controller/PostApiControllerTest.java
@@ -1,58 +1,145 @@
 package com.vibecoding.demo.domain.board.controller;
 
-import com.vibecoding.demo.domain.board.entity.Post;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibecoding.demo.domain.board.dto.PostCreateRequest;
+import com.vibecoding.demo.domain.board.dto.PostResponse;
+import com.vibecoding.demo.domain.board.dto.PostUpdateRequest;
 import com.vibecoding.demo.domain.board.service.PostService;
+import com.vibecoding.demo.domain.member.entity.Member;
+import com.vibecoding.demo.domain.member.entity.Role;
+import com.vibecoding.demo.global.security.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PostApiController.class)
-@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 비활성화 (보안 의존성 충돌 방지)
+@AutoConfigureMockMvc(addFilters = false)
 class PostApiControllerTest {
 
-    @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private PostApiController postApiController;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private PostService postService;
 
     @MockBean
+    private com.vibecoding.demo.global.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.vibecoding.demo.global.security.JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private com.vibecoding.demo.global.security.CustomUserDetailsService customUserDetailsService;
+
+    @MockBean
     private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMappingContext;
 
-    @Test
-    @DisplayName("GET /api/posts 에 offset과 limit 파라미터가 정상 동작한다")
-    void getPosts() throws Exception {
-        // given
-        Post post1 = Post.builder().title("T1").content("C1").author("A1").build();
-        given(postService.getPostsByOffsetAndLimit(2, 1)).willReturn(Arrays.asList(post1));
+    @org.junit.jupiter.api.BeforeEach
+    void setup() {
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup(postApiController)
+                .setCustomArgumentResolvers(new org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver())
+                .setControllerAdvice(new com.vibecoding.demo.global.exception.GlobalExceptionHandler())
+                .build();
+    }
 
-        // when & then
-        mockMvc.perform(get("/api/posts")
-                        .param("offset", "2")
-                        .param("limit", "1"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].title").value("T1"));
+    private CustomUserDetails createUserDetails(Long id, Role role) {
+        Member member = Member.builder()
+                .loginId("user" + id)
+                .password("pass")
+                .name("tester")
+                .email("test@test.com")
+                .role(role)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(member, "id", id);
+        return new CustomUserDetails(member);
     }
 
     @Test
-    @DisplayName("GET /api/posts/count 에 전체 게시글 개수가 정상 반환된다")
-    void getPostCount() throws Exception {
+    @DisplayName("로그인한 사용자는 게시글을 등록할 수 있다")
+    void createPost() throws Exception {
         // given
-        given(postService.getTotalPostCount()).willReturn(15L);
+        PostCreateRequest request = new PostCreateRequest("title", "content");
+        CustomUserDetails userDetails = createUserDetails(1L, Role.USER);
+        org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        );
+        given(postService.createPost(any(PostCreateRequest.class), eq(1L))).willReturn(1L);
 
         // when & then
-        mockMvc.perform(get("/api/posts/count"))
+        mockMvc.perform(post("/api/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(content().string("15"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(1L));
+    }
+
+    @Test
+    @DisplayName("게시글 목록을 조회한다")
+    void getPosts() throws Exception {
+        // given
+        PostResponse post1 = new PostResponse(1L, "T1", "C1", "A1", LocalDateTime.now());
+        given(postService.getPostsByOffsetAndLimit(0, 10)).willReturn(Arrays.asList(post1));
+
+        // when & then
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].title").value("T1"));
+    }
+
+    @Test
+    @DisplayName("게시글을 수정한다")
+    void updatePost() throws Exception {
+        // given
+        PostUpdateRequest request = new PostUpdateRequest("new title", "new content");
+        CustomUserDetails userDetails = createUserDetails(1L, Role.USER);
+        org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        );
+
+        // when & then
+        mockMvc.perform(patch("/api/posts/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("게시글이 수정되었습니다."));
+    }
+
+    @Test
+    @DisplayName("게시글을 삭제한다")
+    void deletePost() throws Exception {
+        // given
+        CustomUserDetails userDetails = createUserDetails(1L, Role.USER);
+        org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        );
+
+        // when & then
+        mockMvc.perform(delete("/api/posts/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("게시글이 삭제되었습니다."));
     }
 }

--- a/src/test/java/com/vibecoding/demo/domain/board/repository/PostRepositoryTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/board/repository/PostRepositoryTest.java
@@ -1,6 +1,9 @@
 package com.vibecoding.demo.domain.board.repository;
 
 import com.vibecoding.demo.domain.board.entity.Post;
+import com.vibecoding.demo.domain.member.entity.Member;
+import com.vibecoding.demo.domain.member.entity.Role;
+import com.vibecoding.demo.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,20 +21,32 @@ class PostRepositoryTest {
     @Autowired
     private PostRepository postRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Test
     @DisplayName("offset과 limit으로 게시글을 조회할 수 있다")
     void findPostsWithOffsetAndLimit() {
         // given
+        Member member = Member.builder()
+                .loginId("tester")
+                .password("password")
+                .name("name")
+                .email("test@test.com")
+                .role(Role.USER)
+                .build();
+        memberRepository.save(member);
+
         for (int i = 1; i <= 15; i++) {
             postRepository.save(Post.builder()
                     .title("Title " + i)
                     .content("Content " + i)
-                    .author("Author")
+                    .member(member)
                     .build());
         }
 
         // when (offset=5, limit=5 => 최신순이므로 15~1 중 ID 내림차순(최신)으로.
-        // 현재 native query: SELECT * FROM posts ORDER BY id DESC OFFSET 5 LIMIT 5
+        // 현재 native query: SELECT * FROM posts ORDER BY id DESC LIMIT :limit OFFSET :offset
         // 전체 ID 역순: 15, 14, 13, 12, 11, [10, 9, 8, 7, 6], 5, 4, 3, 2, 1
         List<Post> result = postRepository.findPostsWithOffsetAndLimit(5, 5);
 

--- a/src/test/java/com/vibecoding/demo/domain/board/service/PostServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/board/service/PostServiceTest.java
@@ -1,7 +1,13 @@
 package com.vibecoding.demo.domain.board.service;
 
+import com.vibecoding.demo.domain.board.dto.PostCreateRequest;
+import com.vibecoding.demo.domain.board.dto.PostResponse;
+import com.vibecoding.demo.domain.board.dto.PostUpdateRequest;
 import com.vibecoding.demo.domain.board.entity.Post;
 import com.vibecoding.demo.domain.board.repository.PostRepository;
+import com.vibecoding.demo.domain.member.entity.Member;
+import com.vibecoding.demo.domain.member.entity.Role;
+import com.vibecoding.demo.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,10 +17,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -25,34 +34,113 @@ class PostServiceTest {
     @Mock
     private PostRepository postRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Member createMember(Long id, String name, Role role) {
+        Member member = Member.builder()
+                .loginId("user" + id)
+                .password("pass")
+                .name(name)
+                .email("email" + id + "@test.com")
+                .role(role)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
     @Test
-    @DisplayName("서비스가 리포지토리의 offset limit 메서드를 올바르게 호출한다")
+    @DisplayName("게시글을 성공적으로 등록한다")
+    void createPost() {
+        // given
+        Long memberId = 1L;
+        PostCreateRequest request = new PostCreateRequest("title", "content");
+        Member member = createMember(memberId, "tester", Role.USER);
+        
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(postRepository.save(any(Post.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        postService.createPost(request, memberId);
+
+        // then
+        verify(postRepository).save(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("게시글 목록을 조회한다")
     void getPostsByOffsetAndLimit() {
         // given
-        Post post1 = Post.builder().title("T1").content("C1").author("A1").build();
-        Post post2 = Post.builder().title("T2").content("C2").author("A2").build();
+        Member member = createMember(1L, "tester", Role.USER);
+        Post post1 = Post.builder().title("T1").content("C1").member(member).build();
+        Post post2 = Post.builder().title("T2").content("C2").member(member).build();
         given(postRepository.findPostsWithOffsetAndLimit(0, 2))
                 .willReturn(Arrays.asList(post1, post2));
 
         // when
-        List<Post> result = postService.getPostsByOffsetAndLimit(0, 2);
+        List<PostResponse> result = postService.getPostsByOffsetAndLimit(0, 2);
 
         // then
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getTitle()).isEqualTo("T1");
-        assertThat(result.get(1).getTitle()).isEqualTo("T2");
+        assertThat(result.get(0).title()).isEqualTo("T1");
+        assertThat(result.get(0).authorName()).isEqualTo("tester");
     }
 
     @Test
-    @DisplayName("서비스가 리포지토리의 count 메서드를 올바르게 호출한다")
-    void getTotalPostCount() {
+    @DisplayName("작성자 본인은 게시글을 수정할 수 있다")
+    void updatePost_success() {
         // given
-        given(postRepository.count()).willReturn(15L);
+        Long postId = 1L;
+        Long memberId = 1L;
+        PostUpdateRequest request = new PostUpdateRequest("new title", "new content");
+        Member member = createMember(memberId, "tester", Role.USER);
+        Post post = Post.builder().title("old").content("old").member(member).build();
+        
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
 
         // when
-        long count = postService.getTotalPostCount();
+        postService.updatePost(postId, request, memberId);
 
         // then
-        assertThat(count).isEqualTo(15L);
+        assertThat(post.getTitle()).isEqualTo("new title");
+        assertThat(post.getContent()).isEqualTo("new content");
+    }
+
+    @Test
+    @DisplayName("작성자가 아니면 게시글을 수정할 수 없다")
+    void updatePost_fail() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long otherId = 2L;
+        PostUpdateRequest request = new PostUpdateRequest("new title", "new content");
+        Member author = createMember(authorId, "author", Role.USER);
+        Post post = Post.builder().title("old").content("old").member(author).build();
+        
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        // when & then
+        assertThatThrownBy(() -> postService.updatePost(postId, request, otherId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("게시글 수정 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("관리자는 다른 사용자의 게시글을 삭제할 수 있다")
+    void deletePost_admin() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long adminId = 99L;
+        Member author = createMember(authorId, "author", Role.USER);
+        Post post = Post.builder().title("T").content("C").member(author).build();
+        
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        // when
+        postService.deletePost(postId, adminId, Role.ADMIN);
+
+        // then
+        verify(postRepository).delete(post);
     }
 }


### PR DESCRIPTION
## 🚀 개요
  사용자가 게시글을 자유롭게 작성하고 소통할 수 있도록 게시판의 핵심 CRUD 기능을 구현했습니다. 특히 보안 요구사항에 맞춰
  사용자 역할(작성자, 관리자, 비인증 사용자)에 따른 세밀한 접근 제어 로직을 적용했습니다.

##  🛠 주요 변경 사항

###  1. 권한 기반 접근 제어 (Security & Authorization)
   - 비인증 사용자 (Public): 게시글 목록 조회(GET /api/posts) 및 상세 조회(GET /api/posts/{id})가 가능하도록 SecurityConfig
     설정을 업데이트했습니다.
   - 인증 사용자 (Logged-in): 게시글 등록(POST /api/posts)은 로그인한 사용자만 가능합니다.
   - 수정 권한: 게시글 수정(PATCH /api/posts/{id})은 작성자 본인만 가능하도록 서비스 레이어에서 검증합니다.
   - 삭제 권한: 게시글 삭제(DELETE /api/posts/{id})는 작성자 본인 또는 관리자(ADMIN) 역할을 가진 사용자만 가능합니다.

###  2. 도메인 모델 및 연관관계 개선
   - Post 엔티티 리팩토링: 기존 문자열(author) 기반 작성자 정보를 Member 엔티티와의 @ManyToOne 연관관계로 개선하여 데이터
     무결성을 확보했습니다.
   - JPA Auditing: BaseTimeEntity를 상속받아 게시글 생성 및 수정 시간을 자동으로 관리합니다.

###  3. API 고도화 및 품질 개선
   - Java 17 record: 모든 요청(PostCreateRequest, PostUpdateRequest)과 응답(PostResponse) DTO를 record로 구현하여 가독성과
     불변성을 높였습니다.
   - 공통 응답 포맷: ApiResponse<T>를 적용하여 성공/실패 여부와 메시지를 포함한 표준화된 응답을 제공합니다.
   - 예외 처리: GlobalExceptionHandler를 개선하여 비즈니스 로직 예외 메시지가 클라이언트에 정확히 전달되도록 수정했습니다.

###  4. 검증 결과
   - Service Test: 권한 시나리오별(본인 수정 성공, 타인 수정 실패, 관리자 삭제 등) 비즈니스 로직 테스트 완료.
   - Controller Test: MockMvc를 통해 @AuthenticationPrincipal 주입 및 API 엔드포인트 동작 확인.
   - PostgreSQL 호환성: Native Query(LIMIT/OFFSET)의 문법 호환성 문제를 해결하여 정상 작동을 확인했습니다.

##  🔗 관련 이슈
   - #5 (게시판 CRUD 파트)