### PR TITLE
feat: [댓글] 최대 2단계(댓글-대댓글) 계층형 댓글 기능 구현 (#6)

### DIFF
--- a/src/main/java/com/vibecoding/demo/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/vibecoding/demo/domain/comment/dto/CommentCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CommentCreateRequest(
         @NotBlank(message = "댓글 내용은 필수입니다.")
-        String content
+        String content,
+        Long parentId
 ) {
 }

--- a/src/main/java/com/vibecoding/demo/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/vibecoding/demo/domain/comment/dto/CommentResponse.java
@@ -1,6 +1,7 @@
 package com.vibecoding.demo.domain.comment.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CommentResponse(
         Long id,
@@ -8,6 +9,7 @@ public record CommentResponse(
         String nickname,
         Long memberId,
         boolean isDeleted,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        List<CommentResponse> children
 ) {
 }

--- a/src/main/java/com/vibecoding/demo/domain/comment/entity/Comment.java
+++ b/src/main/java/com/vibecoding/demo/domain/comment/entity/Comment.java
@@ -9,6 +9,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "comments")
 @Getter
@@ -27,6 +30,13 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> children = new ArrayList<>();
+
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
@@ -34,10 +44,11 @@ public class Comment extends BaseTimeEntity {
     private boolean isDeleted = false;
 
     @Builder
-    public Comment(Post post, Member member, String content) {
+    public Comment(Post post, Member member, String content, Comment parent) {
         this.post = post;
         this.member = member;
         this.content = content;
+        this.parent = parent;
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/vibecoding/demo/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/vibecoding/demo/domain/comment/repository/CommentRepository.java
@@ -11,7 +11,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("select c from Comment c " +
             "join fetch c.member " +
+            "left join fetch c.parent " +
             "where c.post.id = :postId " +
-            "order by c.createdAt asc")
-    List<Comment> findByPostIdWithMember(@Param("postId") Long postId);
+            "order by c.parent.id asc nulls first, c.createdAt asc")
+    List<Comment> findByPostIdWithMemberAndParent(@Param("postId") Long postId);
 }

--- a/src/main/java/com/vibecoding/demo/domain/comment/service/CommentService.java
+++ b/src/main/java/com/vibecoding/demo/domain/comment/service/CommentService.java
@@ -15,6 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,10 +36,25 @@ public class CommentService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
+        Comment parent = null;
+        if (request.parentId() != null) {
+            parent = commentRepository.findById(request.parentId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부모 댓글입니다."));
+            
+            if (parent.getParent() != null) {
+                throw new IllegalArgumentException("댓글은 최대 2단계(대댓글)까지만 작성 가능합니다.");
+            }
+            
+            if (!parent.getPost().getId().equals(postId)) {
+                throw new IllegalArgumentException("부모 댓글과 게시글 정보가 일치하지 않습니다.");
+            }
+        }
+
         Comment comment = Comment.builder()
                 .post(post)
                 .member(member)
                 .content(request.content())
+                .parent(parent)
                 .build();
 
         post.incrementCommentCount();
@@ -47,18 +67,34 @@ public class CommentService {
             throw new IllegalArgumentException("존재하지 않는 게시글입니다.");
         }
 
-        List<Comment> comments = commentRepository.findByPostIdWithMember(postId);
+        List<Comment> comments = commentRepository.findByPostIdWithMemberAndParent(postId);
+        Map<Long, CommentResponse> map = new HashMap<>();
+        List<CommentResponse> roots = new ArrayList<>();
 
-        return comments.stream()
-                .map(c -> new CommentResponse(
-                        c.getId(),
-                        c.isDeleted() ? "삭제된 댓글입니다." : c.getContent(),
-                        c.getMember().getName(),
-                        c.getMember().getId(),
-                        c.isDeleted(),
-                        c.getCreatedAt()
-                ))
-                .toList();
+        comments.forEach(c -> {
+            CommentResponse response = new CommentResponse(
+                    c.getId(),
+                    c.isDeleted() ? "삭제된 댓글입니다." : c.getContent(),
+                    c.getMember().getName(),
+                    c.getMember().getId(),
+                    c.isDeleted(),
+                    c.getCreatedAt(),
+                    new ArrayList<>()
+            );
+            
+            map.put(response.id(), response);
+            
+            if (c.getParent() == null) {
+                roots.add(response);
+            } else {
+                CommentResponse parentResponse = map.get(c.getParent().getId());
+                if (parentResponse != null) {
+                    parentResponse.children().add(response);
+                }
+            }
+        });
+
+        return roots;
     }
 
     @Transactional

--- a/src/test/java/com/vibecoding/demo/domain/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/comment/controller/CommentApiControllerTest.java
@@ -79,7 +79,7 @@ class CommentApiControllerTest {
     @Test
     @DisplayName("댓글을 등록한다")
     void createComment() throws Exception {
-        CommentCreateRequest request = new CommentCreateRequest("comment content");
+        CommentCreateRequest request = new CommentCreateRequest("comment content", null);
         CustomUserDetails userDetails = createUserDetails(1L, Role.USER);
         setAuthentication(userDetails);
         given(commentService.createComment(eq(1L), eq(1L), any(CommentCreateRequest.class))).willReturn(1L);
@@ -95,7 +95,7 @@ class CommentApiControllerTest {
     @Test
     @DisplayName("댓글 목록을 조회한다")
     void getComments() throws Exception {
-        CommentResponse comment = new CommentResponse(1L, "content", "tester", 1L, false, LocalDateTime.now());
+        CommentResponse comment = new CommentResponse(1L, "content", "tester", 1L, false, LocalDateTime.now(), List.of());
         given(commentService.getComments(1L)).willReturn(List.of(comment));
 
         mockMvc.perform(get("/api/posts/1/comments"))

--- a/src/test/java/com/vibecoding/demo/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/comment/service/CommentServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -46,7 +47,7 @@ class CommentServiceTest {
         // given
         Long postId = 1L;
         Long memberId = 1L;
-        CommentCreateRequest request = new CommentCreateRequest("content");
+        CommentCreateRequest request = new CommentCreateRequest("content", null);
         Member member = Member.builder().loginId("user").password("pass").name("name").email("email").role(Role.USER).build();
         Post post = Post.builder().title("title").content("content").member(member).build();
         
@@ -63,26 +64,55 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("댓글 목록을 조회한다")
+    @DisplayName("계층형 댓글(2-Depth) 목록을 조회한다")
     void getComments() {
         // given
         Long postId = 1L;
         Member member = Member.builder().loginId("user").password("pass").name("name").email("email").role(Role.USER).build();
         Post post = Post.builder().title("title").content("content").member(member).build();
         
-        Comment comment1 = Comment.builder().post(post).member(member).content("comment1").build();
-        Comment comment2 = Comment.builder().post(post).member(member).content("comment2").build();
+        Comment parent = Comment.builder().post(post).member(member).content("parent").build();
+        org.springframework.test.util.ReflectionTestUtils.setField(parent, "id", 1L);
+        
+        Comment child = Comment.builder().post(post).member(member).content("child").parent(parent).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(child, "id", 2L);
 
         given(postRepository.existsById(postId)).willReturn(true);
-        given(commentRepository.findByPostIdWithMember(postId)).willReturn(List.of(comment1, comment2));
+        given(commentRepository.findByPostIdWithMemberAndParent(postId)).willReturn(List.of(parent, child));
 
         // when
         List<CommentResponse> result = commentService.getComments(postId);
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).content()).isEqualTo("comment1");
-        assertThat(result.get(1).content()).isEqualTo("comment2");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).content()).isEqualTo("parent");
+        assertThat(result.get(0).children()).hasSize(1);
+        assertThat(result.get(0).children().get(0).content()).isEqualTo("child");
+    }
+
+    @Test
+    @DisplayName("3단계 이상의 댓글 작성 시도 시 예외가 발생한다")
+    void createComment_depth_limit() {
+        // given
+        Long postId = 1L;
+        Long memberId = 1L;
+        CommentCreateRequest request = new CommentCreateRequest("depth 3", 2L);
+        
+        Member member = Member.builder().loginId("user").password("pass").name("name").email("email").role(Role.USER).build();
+        Post post = Post.builder().title("title").content("content").member(member).build();
+        
+        Comment parent = Comment.builder().post(post).member(member).content("parent").build();
+        Comment child = Comment.builder().post(post).member(member).content("child").parent(parent).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(child, "id", 2L);
+
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(commentRepository.findById(2L)).willReturn(Optional.of(child));
+
+        // when & then
+        assertThatThrownBy(() -> commentService.createComment(postId, memberId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("댓글은 최대 2단계(대댓글)까지만 작성 가능합니다.");
     }
 
     @Test


### PR DESCRIPTION
## 🚀 개요
단층 구조였던 댓글 시스템을 부모-자식 관계를 가진 계층형 구조로 고도화했습니다. 무분별한 깊이 생성을 방지하기 위해 최대 2단계(대댓글)까지만 허용하도록 설계했습니다.

## 🛠 주요 변경 사항
### 1. 계층형 도메인 모델 구축
- **셀프 참조 도입:** `Comment` 엔티티 내에 `parent`와 `children` 필드를 추가하여 부모 댓글과 자식 댓글 간의 연관관계를
      설정했습니다.
- **2단계 깊이 제한 로직:**
    - 댓글 등록 시 `parentId`가 있는 경우, 해당 부모 댓글이 이미 자식 댓글(이미 `parent`가 존재)인지 검증합니다.
    - 3단계 이상의 깊이(대댓글의 댓글)가 생성되는 것을 비즈니스 로직 수준에서 차단하여 복잡도를 관리합니다.
### 2. 효율적인 계층형 데이터 조회
- **트리 구조 DTO:** `CommentResponse` 내부에 `List<CommentResponse> children` 필드를 추가하여 중첩된 트리 구조로
      응답합니다.
- **성능 최적화:**
    - `CommentRepository`에서 `left join fetch c.parent`를 사용하여 계층 구조 판단에 필요한 정보를 한 번의 쿼리로
      조회합니다.
     - `CommentService`에서 플랫한 결과를 Map을 활용하여 효율적으로 트리 구조로 재구성합니다.

### 3. 게시글 상세 조회 연동
- 특정 게시글 조회 API(`GET /api/posts/{postId}`) 호출 시, 이제 평면 리스트가 아닌 **2단계 계층 구조가 적용된 댓글
      목록**을 응답으로 제공합니다.

---
## 🛣 API 명세 및 변경 사항
| 기능 | 메서드 | 엔드포인트 | 변경 사항 |
| :--- | :---: | :--- | :--- |
| **댓글 등록** | `POST` | `/api/posts/{postId}/comments` | `parentId` 필드 추가 (대댓글 작성 시 사용) |
| **댓글 조회** | `GET` | `/api/posts/{postId}/comments` | 대댓글이 부모 댓글의 `children` 리스트에 포함되어 반환 |

---
## ✅ 테스트 및 검증 결과
- **계층 구조 검증:** 부모 댓글 조회 시 하위에 달린 대댓글들이 정상적으로 매핑되는지 확인.
- **깊이 제한 테스트:** 2단계 대댓글에 다시 댓글을 달려고 시도할 때 `IllegalArgumentException` 발생 여부 검증.
- **통합 검증:** `./gradlew test`를 통해 기존 기능과의 호환성 및 신규 로직 동작 확인 완료.

## 🔗 관련 이슈
- Close #6