### PR TITLE
feat: [댓글] 무한 Depth 계층형 댓글 기능 구현 (#7)

### DIFF
--- a/src/main/java/com/vibecoding/demo/domain/comment/service/CommentService.java
+++ b/src/main/java/com/vibecoding/demo/domain/comment/service/CommentService.java
@@ -41,10 +41,6 @@ public class CommentService {
             parent = commentRepository.findById(request.parentId())
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부모 댓글입니다."));
             
-            if (parent.getParent() != null) {
-                throw new IllegalArgumentException("댓글은 최대 2단계(대댓글)까지만 작성 가능합니다.");
-            }
-            
             if (!parent.getPost().getId().equals(postId)) {
                 throw new IllegalArgumentException("부모 댓글과 게시글 정보가 일치하지 않습니다.");
             }

--- a/src/test/java/com/vibecoding/demo/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/comment/service/CommentServiceTest.java
@@ -64,35 +64,40 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("계층형 댓글(2-Depth) 목록을 조회한다")
+    @DisplayName("계층형 댓글(Infinite-Depth) 목록을 조회한다")
     void getComments() {
         // given
         Long postId = 1L;
         Member member = Member.builder().loginId("user").password("pass").name("name").email("email").role(Role.USER).build();
         Post post = Post.builder().title("title").content("content").member(member).build();
         
-        Comment parent = Comment.builder().post(post).member(member).content("parent").build();
-        org.springframework.test.util.ReflectionTestUtils.setField(parent, "id", 1L);
+        Comment depth1 = Comment.builder().post(post).member(member).content("depth1").build();
+        org.springframework.test.util.ReflectionTestUtils.setField(depth1, "id", 1L);
         
-        Comment child = Comment.builder().post(post).member(member).content("child").parent(parent).build();
-        org.springframework.test.util.ReflectionTestUtils.setField(child, "id", 2L);
+        Comment depth2 = Comment.builder().post(post).member(member).content("depth2").parent(depth1).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(depth2, "id", 2L);
+
+        Comment depth3 = Comment.builder().post(post).member(member).content("depth3").parent(depth2).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(depth3, "id", 3L);
 
         given(postRepository.existsById(postId)).willReturn(true);
-        given(commentRepository.findByPostIdWithMemberAndParent(postId)).willReturn(List.of(parent, child));
+        given(commentRepository.findByPostIdWithMemberAndParent(postId)).willReturn(List.of(depth1, depth2, depth3));
 
         // when
         List<CommentResponse> result = commentService.getComments(postId);
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).content()).isEqualTo("parent");
+        assertThat(result.get(0).content()).isEqualTo("depth1");
         assertThat(result.get(0).children()).hasSize(1);
-        assertThat(result.get(0).children().get(0).content()).isEqualTo("child");
+        assertThat(result.get(0).children().get(0).content()).isEqualTo("depth2");
+        assertThat(result.get(0).children().get(0).children()).hasSize(1);
+        assertThat(result.get(0).children().get(0).children().get(0).content()).isEqualTo("depth3");
     }
 
     @Test
-    @DisplayName("3단계 이상의 댓글 작성 시도 시 예외가 발생한다")
-    void createComment_depth_limit() {
+    @DisplayName("3단계 이상의 깊은 댓글도 성공적으로 생성한다")
+    void createComment_infinite_depth() {
         // given
         Long postId = 1L;
         Long memberId = 1L;
@@ -100,19 +105,25 @@ class CommentServiceTest {
         
         Member member = Member.builder().loginId("user").password("pass").name("name").email("email").role(Role.USER).build();
         Post post = Post.builder().title("title").content("content").member(member).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(post, "id", postId);
         
-        Comment parent = Comment.builder().post(post).member(member).content("parent").build();
-        Comment child = Comment.builder().post(post).member(member).content("child").parent(parent).build();
-        org.springframework.test.util.ReflectionTestUtils.setField(child, "id", 2L);
+        Comment depth1 = Comment.builder().post(post).member(member).content("depth1").build();
+        org.springframework.test.util.ReflectionTestUtils.setField(depth1, "id", 1L);
+
+        Comment depth2 = Comment.builder().post(post).member(member).content("depth2").parent(depth1).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(depth2, "id", 2L);
 
         given(postRepository.findById(postId)).willReturn(Optional.of(post));
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(commentRepository.findById(2L)).willReturn(Optional.of(child));
+        given(commentRepository.findById(2L)).willReturn(Optional.of(depth2));
+        given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        // when & then
-        assertThatThrownBy(() -> commentService.createComment(postId, memberId, request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("댓글은 최대 2단계(대댓글)까지만 작성 가능합니다.");
+        // when
+        commentService.createComment(postId, memberId, request);
+
+        // then
+        verify(commentRepository).save(any(Comment.class));
+        assertThat(post.getCommentCount()).isEqualTo(1L);
     }
 
     @Test


### PR DESCRIPTION
## 🚀 개요
단층 및 2단계로 제한되었던 댓글 시스템을 무한한 깊이의 계층형 구조(Recursive Hierarchical Structure)로 고도화했습니다. 이를 통해 사용자들이 보다 풍부하고 자유로운 소통을 할 수 있는 기반을 마련했습니다.

## 🛠 주요 변경 사항

1. **깊이 제한 해제**
    - **제한 로직 제거**: 기존에 존재하던 최대 2단계(대댓글) 작성 제한 로직을 서비스 레이어에서 제거하여 무제한 Depth를
      지원합니다.
     - **재귀적 생성**: 어떤 깊이의 댓글이든 부모 댓글의 ID만 있다면 그 하위로 새로운 댓글을 작성할 수 있습니다.
2. **재귀적 계층 조회 지원**
     - **트리 구조 유지**: CommentResponse DTO의 children 리스트 구조를 활용하여, 깊이에 상관없이 전체 댓글 리스트를 트리 구조로 재구성하여 반환합니다.
     - **데이터 정합성**: 대댓글 작성 시 부모 댓글이 속한 게시글 ID와 현재 요청된 게시글 ID가 일치하는지 검증하는 로직을 유지하여 데이터 무결성을 보장합니다.
3. **테스트 고도화**
     - **Infinite Depth 검증**: 3단계(Depth 3) 이상의 깊은 댓글이 정상적으로 생성되고, 조회 시 올바른 부모-자식 관계로 매핑되는지 확인하는 테스트 케이스를 추가했습니다.
     - **정상 작동 확인**: 모든 댓글 및 게시판 관련 테스트를 통과하여 기존 기능과의 호환성을 확인했습니다.

## 🛣 API 명세 및 변경 사항
| 기능 | 메서드 | 엔드포인트 | 설명 |
| :--- | :---: | :--- | :--- |
| **댓글 등록** | POST | /api/posts/{postId}/comments | parentId에 어떤 단계의 댓글 ID를 넣어도 하위 댓글로 등록 가능 |
| **댓글 조회** | GET | /api/posts/{postId}/comments | 전체 계층 구조가 중첩된 children 리스트 형태로 반환됨 |

## ✅ 테스트 및 검증 결과
 - **1.** 3단계 이상의 깊은 계층형 댓글 생성 및 조회 테스트 성공.
 - **2.** 부모 댓글-게시글 불일치 시 예외 처리 검증 완료.
 - **3.** `./gradlew test`를 통한 전체 도메인 기능 무결성 확인 완료.

## 🔗 관련 이슈
 - Close #7