### PR TITLE
feat: [조회수] 쿠키 기반 조회수 어뷰징 정책 구현 (#13)

### DIFF
--- a/src/main/java/com/vibecoding/demo/domain/posts/controller/PostApiController.java
+++ b/src/main/java/com/vibecoding/demo/domain/posts/controller/PostApiController.java
@@ -2,14 +2,19 @@ package com.vibecoding.demo.domain.posts.controller;
 
 import com.vibecoding.demo.domain.posts.dto.*;
 import com.vibecoding.demo.domain.posts.service.PostService;
-import com.vibecoding.demo.global.security.CustomUserDetails;
 import com.vibecoding.demo.global.dto.ApiResponse;
+import com.vibecoding.demo.global.security.CustomUserDetails;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -36,9 +41,52 @@ public class PostApiController {
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long postId) {
+    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(
+            @PathVariable Long postId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        
+        handleViewCount(postId, request, response);
         PostDetailResponse post = postService.getPostDetail(postId);
         return ResponseEntity.ok(ApiResponse.success(post));
+    }
+
+    private void handleViewCount(Long postId, HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+        Cookie oldCookie = null;
+        
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("viewed_posts")) {
+                    oldCookie = cookie;
+                    break;
+                }
+            }
+        }
+
+        if (oldCookie == null) {
+            postService.increaseViewCount(postId);
+            Cookie newCookie = new Cookie("viewed_posts", "[" + postId + "]");
+            newCookie.setPath("/");
+            newCookie.setHttpOnly(true);
+            newCookie.setMaxAge((int) getSecondsUntilMidnight());
+            response.addCookie(newCookie);
+        } else {
+            if (!oldCookie.getValue().contains("[" + postId + "]")) {
+                postService.increaseViewCount(postId);
+                oldCookie.setValue(oldCookie.getValue() + "[" + postId + "]");
+                oldCookie.setPath("/");
+                oldCookie.setHttpOnly(true);
+                oldCookie.setMaxAge((int) getSecondsUntilMidnight());
+                response.addCookie(oldCookie);
+            }
+        }
+    }
+
+    private long getSecondsUntilMidnight() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay();
+        return Duration.between(now, midnight).getSeconds();
     }
 
     @PatchMapping("/{postId}")

--- a/src/main/java/com/vibecoding/demo/domain/posts/dto/PostDetailResponse.java
+++ b/src/main/java/com/vibecoding/demo/domain/posts/dto/PostDetailResponse.java
@@ -11,6 +11,7 @@ public record PostDetailResponse(
         String content,
         String authorName,
         long commentCount,
+        long viewCount,
         LocalDateTime createdAt,
         List<CommentResponse> comments
 ) {

--- a/src/main/java/com/vibecoding/demo/domain/posts/dto/PostListResponse.java
+++ b/src/main/java/com/vibecoding/demo/domain/posts/dto/PostListResponse.java
@@ -7,6 +7,7 @@ public record PostListResponse(
         String title,
         String authorName,
         long commentCount,
+        long viewCount,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/vibecoding/demo/domain/posts/entity/Post.java
+++ b/src/main/java/com/vibecoding/demo/domain/posts/entity/Post.java
@@ -31,6 +31,9 @@ public class Post extends BaseTimeEntity {
     @Column(name = "comment_count", nullable = false)
     private long commentCount = 0;
 
+    @Column(name = "view_count", nullable = false)
+    private long viewCount = 0;
+
     @Builder
     public Post(String title, String content, Member member) {
         this.title = title;
@@ -51,5 +54,9 @@ public class Post extends BaseTimeEntity {
         if (this.commentCount > 0) {
             this.commentCount--;
         }
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
     }
 }

--- a/src/main/java/com/vibecoding/demo/domain/posts/service/PostService.java
+++ b/src/main/java/com/vibecoding/demo/domain/posts/service/PostService.java
@@ -44,6 +44,7 @@ public class PostService {
                         post.getTitle(),
                         post.getMember().getName(),
                         post.getCommentCount(),
+                        post.getViewCount(),
                         post.getCreatedAt()
                 ))
                 .collect(Collectors.toList());
@@ -59,9 +60,17 @@ public class PostService {
                 post.getContent(),
                 post.getMember().getName(),
                 post.getCommentCount(),
+                post.getViewCount(),
                 post.getCreatedAt(),
                 commentService.getComments(postId)
         );
+    }
+
+    @Transactional
+    public void increaseViewCount(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+        post.incrementViewCount();
     }
 
     @Transactional
@@ -106,6 +115,7 @@ public class PostService {
                         post.getTitle(),
                         post.getMember().getName(),
                         post.getCommentCount(),
+                        post.getViewCount(),
                         post.getCreatedAt()
                 ))
                 .collect(Collectors.toList());

--- a/src/test/java/com/vibecoding/demo/domain/posts/controller/PostApiControllerTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/posts/controller/PostApiControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -95,13 +96,28 @@ class PostApiControllerTest {
     @Test
     @DisplayName("게시글 목록을 조회한다")
     void getPosts() throws Exception {
-        PostListResponse post1 = new PostListResponse(1L, "T1", "tester", 0, LocalDateTime.now());
+        PostListResponse post1 = new PostListResponse(1L, "T1", "tester", 0, 0, LocalDateTime.now());
         given(postService.getPostsByOffsetAndLimit(0, 10)).willReturn(Arrays.asList(post1));
 
         mockMvc.perform(get("/api/posts"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data[0].title").value("T1"));
+    }
+
+    @Test
+    @DisplayName("GET /api/posts/{postId} 가 상세 정보와 댓글을 반환한다")
+    void getPostDetail() throws Exception {
+        // given
+        PostDetailResponse post = new PostDetailResponse(1L, "T1", "C1", "A1", 0, 0, LocalDateTime.now(), List.of());
+        given(postService.getPostDetail(1L)).willReturn(post);
+
+        // when & then
+        mockMvc.perform(get("/api/posts/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("T1"))
+                .andExpect(jsonPath("$.data.comments").isArray());
     }
 
     @Test

--- a/src/test/java/com/vibecoding/demo/domain/posts/service/PostServiceTest.java
+++ b/src/test/java/com/vibecoding/demo/domain/posts/service/PostServiceTest.java
@@ -89,6 +89,7 @@ class PostServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).title()).isEqualTo("T1");
         assertThat(result.get(0).authorName()).isEqualTo("tester");
+        assertThat(result.get(0).viewCount()).isEqualTo(0L);
     }
 
     @Test
@@ -106,7 +107,24 @@ class PostServiceTest {
 
         // then
         assertThat(result.title()).isEqualTo("T1");
+        assertThat(result.viewCount()).isEqualTo(0L);
         assertThat(result.comments()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조회수를 증가시킨다")
+    void increaseViewCount() {
+        // given
+        Long postId = 1L;
+        Member member = createMember(1L, "tester", Role.USER);
+        Post post = Post.builder().title("T").content("C").member(member).build();
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        // when
+        postService.increaseViewCount(postId);
+
+        // then
+        assertThat(post.getViewCount()).isEqualTo(1L);
     }
 
     @Test


### PR DESCRIPTION
## 🚀 개요
게시글의 조회수 기능을 구현하고, 무분별한 조회수 조작을 방지하기 위한 쿠키 기반의 어뷰징 방지 정책을 수립 및 적용했습니다.

## 🛠 주요 변경 사항
1. **조회수 데이터 모델링**
    - **Post 엔티티 개선**: 조회수를 저장할 `viewCount` 필드를 추가하고, 비즈니스 로직에서 안전하게 증가시킬 수 있는 `incrementViewCount()` 메서드를 구현했습니다.
    - **DB 스키마**: `view_count` 컬럼을 추가했습니다 (BIGINT, default 0).
2. **어뷰징 방지 정책 (쿠키 기반)**
    - **동작 방식**: 게시글 상세 조회 시 `viewed_posts`라는 이름의 쿠키를 확인합니다.
    - **중복 검증**: 쿠키 값에 해당 게시글 ID가 없는 경우에만 DB 조회수를 증가시키고, 쿠키에 해당 ID를 추가합니다.
    - **자정 초기화**: 사용자가 하루에 한 번만 조회수를 올릴 수 있도록, 쿠키의 만료 시간을 **매일 자정(00:00:00)**으로 설정했습니다.
    - **보안 강화**: `HttpOnly` 속성을 적용하여 클라이언트 사이드 스크립트(JS)를 통한 쿠키 조작 및 접근을 차단했습니다.
3. **DTO 및 API 연동**
    - **PostListResponse/PostDetailResponse**: 목록 및 상세 조회 응답에 `viewCount` 필드를 추가하여 사용자에게 노출하도록 했습니다.
    - **PostService**: 조회수 증가를 위한 별도의 트랜잭션 메서드를 추가했습니다.
## 🛣 API 변경 사항 및 명세
| 기능 | 메서드 | 엔드포인트 | 변경 사항 |
| :--- | :---: | :--- | :--- |
| **게시글 상세 조회** | GET | /api/posts/{postId} | 호출 시 쿠키를 검증하여 조건부로 조회수 증가 로직 실행 |
| **게시글 목록 조회** | GET | /api/posts | 응답 데이터에 `viewCount` 필드 포함 |
## ✅ 테스트 및 검증 결과
- **1. 조회수 증가 로직**: 새로운 사용자가 접속 시 조회수가 1 증가하는 것을 PostServiceTest를 통해 검증 완료.
- **2. 쿠키 기반 중복 방지**: 동일한 요청에 대해 쿠키가 존재하는 경우 조회수가 유지되는 로직 확인.
- **3. 통합 테스트**: 기존 게시판 CRUD 및 댓글 기능과의 호환성을 위해 전체 도메인 테스트를 수행하여 성공(BUILD SUCCESSFUL) 확인.
## 🔗 관련 이슈
- Close #13